### PR TITLE
feat: enhance decimal handling with rounding and padding rules in Nepali number conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,40 @@ digitToNepaliWords(1.23, {
 // Output: "one point twenty three"
 ```
 
+### Decimal Handling Rules
+
+The library follows these rules for decimal places:
+
+1. **Rounding**: If there are more than 2 decimal places, the number is rounded to 2 decimal places
+   ```typescript
+   digitToNepaliWords(1.567, { includeDecimal: true })
+   // => "एक दशमलव सन्ताउन्न"  (rounds to 1.57)
+
+   digitToNepaliWords(1.999, { includeDecimal: true })
+   // => "दुई"  (rounds to 2.00)
+   ```
+
+2. **Padding**: Single decimal digits are padded with a zero
+   ```typescript
+   digitToNepaliWords(1.5, { includeDecimal: true })
+   // => "एक दशमलव पचास"  (pads to 1.50)
+   ```
+
+3. **Currency Format**: These rules apply to both regular and currency formats
+   ```typescript
+   digitToNepaliWords(1.567, { 
+     isCurrency: true,
+     includeDecimal: true 
+   })
+   // => "रुपैयाँ एक पैसा सन्ताउन्न"  (rounds to 1.57)
+
+   digitToNepaliWords(1.5, { 
+     isCurrency: true,
+     includeDecimal: true 
+   })
+   // => "रुपैयाँ एक पैसा पचास"  (pads to 1.50)
+   ```
+
 ## Configuration Options
 
 ```typescript

--- a/src/converters/nepaliConverter.ts
+++ b/src/converters/nepaliConverter.ts
@@ -397,13 +397,27 @@ class NumberConverter {
     integer: bigint;
     decimal?: string;
   } {
-    const str = num.toString();
-    const [intPart, decPart] = str.split(".");
-
     try {
+      // Convert the input to a number first for proper decimal handling
+      const numValue = typeof num === 'bigint' ? Number(num) : Number(num);
+      
+      // Round to 2 decimal places
+      const rounded = Math.round(numValue * 100) / 100;
+      
+      // Convert to string and split
+      const [intPart, decPart] = rounded.toString().split('.');
+      
+      let processedDecimal: string | undefined = decPart;
+      if (processedDecimal) {
+        // Pad single digit with zero
+        if (processedDecimal.length === 1) {
+          processedDecimal = processedDecimal + '0';
+        }
+      }
+  
       return {
         integer: BigInt(intPart),
-        decimal: decPart,
+        decimal: processedDecimal,
       };
     } catch {
       throw new Error("Input must contain only valid digits");
@@ -463,21 +477,13 @@ class NumberConverter {
     );
 
     // Always add zero for whole numbers or undefined decimal
-    if (!decimal || decimal === "0") {
+    if (!decimal || decimal === "0" || decimal === "00") {
       words.push(this.getWordMapping(0, config.lang));
       return;
     }
 
-    let decimalNum: number;
-    if (config.isCurrency) {
-      // For currency: pad to 2 digits, handle .5 as 50, .05 as 5
-      const paddedDecimal = decimal.padEnd(2, "0").slice(0, 2);
-      decimalNum = parseInt(paddedDecimal);
-    } else {
-      // For non-currency: keep original value
-      decimalNum = parseInt(decimal);
-    }
-
+    // For currency or regular decimal, use the processed decimal value
+    const decimalNum = parseInt(decimal);
     words.push(this.getWordMapping(decimalNum, config.lang));
   }
 

--- a/tests/nepaliConverter.test.ts
+++ b/tests/nepaliConverter.test.ts
@@ -192,13 +192,31 @@ describe("Nepali Number to Words Converter", () => {
         expect(result).toBe("dollars एक cents पचास");
       });
 
-      it("should truncate to 2 decimal places in currency", () => {
+      it("should round decimal places greater than 2 digits", () => {
         const result = digitToNepaliWords(1.567, {
           isCurrency: true,
           includeDecimal: true,
           lang: "ne"
         });
-        expect(result).toBe("रुपैयाँ एक पैसा छपन्न");
+        expect(result).toBe("रुपैयाँ एक पैसा सन्ताउन्न");
+      });
+
+      it("should round up decimal .999 to next integer", () => {
+        const result = digitToNepaliWords(1.999, {
+          isCurrency: true,
+          includeDecimal: true,
+          lang: "ne"
+        });
+        expect(result).toBe("रुपैयाँ दुई");
+      });
+
+      it("should pad single decimal digit with zero", () => {
+        const result = digitToNepaliWords(1.5, {
+          isCurrency: true,
+          includeDecimal: true,
+          lang: "ne"
+        });
+        expect(result).toBe("रुपैयाँ एक पैसा पचास");
       });
     });
 
@@ -208,7 +226,7 @@ describe("Nepali Number to Words Converter", () => {
           includeDecimal: true,
           lang: "ne" 
         });
-        expect(result).toBe("एक दशमलव पाँच");
+        expect(result).toBe("एक दशमलव पचास");
       });
 
       it("should handle zero decimal part", () => {
@@ -232,7 +250,23 @@ describe("Nepali Number to Words Converter", () => {
           includeDecimal: true,
           decimalSuffix: "point"
         });
-        expect(result).toBe("एक point पाँच");
+        expect(result).toBe("एक point पचास");
+      });
+
+      it("should round long decimals to 2 places", () => {
+        const result = digitToNepaliWords(1.237, { 
+          includeDecimal: true,
+          lang: "ne" 
+        });
+        expect(result).toBe("एक दशमलव चौबिस");
+      });
+
+      it("should pad single decimal digit", () => {
+        const result = digitToNepaliWords(1.5, { 
+          includeDecimal: true,
+          lang: "ne" 
+        });
+        expect(result).toBe("एक दशमलव पचास");
       });
     });
   });


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of decimal numbers in the Nepali number-to-words conversion library. The changes include new rules for rounding and padding decimals, updates to the conversion logic, and additional test cases to ensure correctness.

### Decimal Handling Rules:

* Added detailed rules for handling decimal numbers, including rounding to two decimal places, padding single decimal digits with a zero, and applying these rules to both regular and currency formats in `README.md`.

### Conversion Logic Updates:

* Updated the `NumberConverter` class in `src/converters/nepaliConverter.ts` to round numbers to two decimal places, pad single decimal digits, and handle both regular and currency formats consistently. [[1]](diffhunk://#diff-de290584ce22fe64f2ed43af7959501690cee8711f2ad8088100be2344552850L400-R420) [[2]](diffhunk://#diff-de290584ce22fe64f2ed43af7959501690cee8711f2ad8088100be2344552850L466-R486)

### Test Enhancements:

* Added new test cases in `tests/nepaliConverter.test.ts` to verify the correct rounding of decimals, rounding up of .999 to the next integer, and padding of single decimal digits. [[1]](diffhunk://#diff-2f76a6ff0c3b797cd965f4c84f8fd07c6e114b81f7a354f5004ee6ab89c8f8a4L195-R219) [[2]](diffhunk://#diff-2f76a6ff0c3b797cd965f4c84f8fd07c6e114b81f7a354f5004ee6ab89c8f8a4L211-R229) [[3]](diffhunk://#diff-2f76a6ff0c3b797cd965f4c84f8fd07c6e114b81f7a354f5004ee6ab89c8f8a4L235-R269)